### PR TITLE
Update "How to participate" section in testnet announcement

### DIFF
--- a/packages/website/_posts/diva-testnet-announcement.mdx
+++ b/packages/website/_posts/diva-testnet-announcement.mdx
@@ -74,18 +74,22 @@ interact with the DIVA App and later to claim the DIVA token. It should look as 
 
 ![register](/images/posts/register.png)
 - **Make sure you are using an address that you control as you won't be able to change it afterwards!** 
-- Hit Enter to confirm. In addition to the address registration, you will receive test ERC20 tokens called [dUSD](https://ropsten.etherscan.io/address/0x134e62bd2ee247d4186A1fdbaA9e076cb26c1355) and test ETH on the Ropsten network that you will need to start 
+- Hit Enter to confirm. In addition to the address registration, you will receive test ERC20 tokens called [dUSD](https://ropsten.etherscan.io/address/0x134e62bd2ee247d4186A1fdbaA9e076cb26c1355) that you will need to start 
 testing the app. 
 - Type **/address** to confirm that your address has been registered. You can also use this command to check which 
 account you have registered in case you forget it.
 - Type **/claim-test-assets** to receive more dUSD tokens for testing (works only for registered users). Note that you can claim test assets once per day. 
-Further, note that you will not receive any ETH when running this command. Use [this](https://faucet.egorfine.com/) if you need more Ropsten ETH.
 
 All available commands to interact with our Discord bot are also listed in the testnet channel:
 
 ![register](/images/posts/testnet_bot.png)
 
 **Note that each verified Discord user can only register one single account.** Users have time to register and complete all tasks until **30th September 2022**. 
+
+After you have registered and received dUSD, claim some Ropsten ETH from one of the following faucets to be able to pay for gas when transacting on the Ropsten network:
+* [Paradigm faucet](https://faucet.paradigm.xyz/)
+* [Egorfine faucet](https://faucet.egorfine.com/) 
+
 
 ### List of tasks
 


### PR DESCRIPTION
How that the discord bot is no longer providing Ropsten ETH and only dUSD, I have updated the announcement to avoid any confusion in the future.