### PR TITLE
Discord link changes in testnet announcement post

### DIFF
--- a/packages/website/_posts/diva-testnet-announcement.mdx
+++ b/packages/website/_posts/diva-testnet-announcement.mdx
@@ -175,6 +175,6 @@ today and give our system a test drive.
 - Website: https://www.divaprotocol.io/ 
 - App: https://app.diva.finance/
 - Twitter: https://twitter.com/divaprotocol_io 
-- Discord: https://discord.gg/Pc7UBqxu2b 
+- Discord: https://discord.gg/8fAvUspmv3
 - Gitbook: https://docs.divaprotocol.io/ 
 


### PR DESCRIPTION
In the testnet announcement post changed the Discord link to -https://discord.gg/8fAvUspmv3