### PR TITLE
Update decimal precision

### DIFF
--- a/packages/website/src/pages/api/rewards/[address].ts
+++ b/packages/website/src/pages/api/rewards/[address].ts
@@ -85,7 +85,7 @@ export default async function handler(
   const resUserReward = {
     address: userTokenClaim.address,
     reward:
-      Number(toStringFixed(userTokenClaim.amount, DIVA_TOKEN_DECIMALS, 8)),
+      Number(toStringFixed(userTokenClaim.amount, DIVA_TOKEN_DECIMALS, 9)),
     time: userTokenClaim.time
   }
 


### PR DESCRIPTION
Some allocations have 9 decimals, but the current configuration assumes 8 as the max. This PR fixes this issue.